### PR TITLE
fix: add integration_category field to config endpoint

### DIFF
--- a/app/routers/intergration_config.py
+++ b/app/routers/intergration_config.py
@@ -20,6 +20,7 @@ integration_json = {
         },
         "is_active": True,
         "integration_type": "interval",
+        "integration_category": "data analytics & visualization",
         "key_features": [
             "📊 Automated Business Insights – Provides weekly analytics-driven insights to improve decision-making.\n🔍 Google Analytics Integration – Uses Google Analytics data to track website performance.\n⏳ Scheduled Reports – Runs automatically every Monday at 9 AM to deliver fresh insights.\n📢 Actionable Recommendations – Offers data-driven suggestions to boost engagement and conversions.\n🚀 Telex Integration – Sends insights directly to your Telex channels for seamless notifications."
         ],


### PR DESCRIPTION
Added the missing 'integration_category' field with value 'data analytics and visualization' 
to resolve integration registration errors. This field is required by the Telex App Store
for proper categorization of the integration.